### PR TITLE
add -H and -P for tcp connection to gpsd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
+click = "^8.0"
 prometheus-client = "^0.9.0"
 gps = "^3.19"
 argparse = "^1.4.0"


### PR DESCRIPTION
Thank you for your work on this exporter. I use it in a kubernetes environment on a node that runs in my car for tracking purposes. For that I needed your exporter to be able to connect to a remote gpsd instance, so I added -H and -P. -P has a default value of 2947, which is gpsd default port. -H is set to None. 

I also had to remove gps_connect and make the connection once on program start, otherwise it constantly would open sockets which led to kubernetes kill the pod. I don't have a good or in-depth explanation on this but removing gps_connect and moving the connection logic to main() fixed that problem.

Click was missing as a dependency, so I added that too. It also required python to be >= 3.8, but it works on 3.7 for me so I lowered the requirement. It propably works with lower versions, too. Click may work with lower verions, too. I don't know anything about click. 

I build a [docker container](https://git.lother.io/lotherk/docker/src/branch/master/gpsd_exporter) and a [helm chart](https://git.lother.io/lotherk/charts/src/branch/master/gpsd) around it. Both are still in development and work for me as they are but I will make them more user friendly, probably.

It would be absolutely okay for me if you don't want to merge this request but it would be great if you could implement specifying host and port of a remote gpsd instance.

Again, thank you. I did not expect to find a gpsd exporter for prometheus and am very happy you did one. :-)